### PR TITLE
feat: do not remove attribute if user is in admin

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,5 +1,12 @@
 // ferret One のクリックイベント計測のトリガー属性を削除
-const elements = document.querySelectorAll('[data-hu-event]');
-[...elements].forEach(node => {
-  node.removeAttribute('data-hu-event');
-});
+const removeDataHuEventAttr = () => {
+  const elements = document.querySelectorAll('[data-hu-event]');
+  [...elements].forEach(node => {
+    node.removeAttribute('data-hu-event');
+  });
+}
+
+// ferret One 管理画面以外では、data-hu-event 属性を削除
+if (location.hostname !== 'app.ferret-one.com') {
+  removeDataHuEventAttr();
+}


### PR DESCRIPTION
# やったこと

ユーザーが管理画面にいる状況では、`data-hu-event 属性` の削除は行わないようにしました。（つまり、公開サイト側でのみ属性削除がうごくようにしました。）

# 背景

管理画面側で、ページ編集を行う場合に、`data-hu-event 属性` が削除されると困るという声が多かったため。

# 動作確認について

`content-script.js` の内容を、管理画面/公開サイト側で、それぞれ叩き意図した動作となるところまで確認しました。